### PR TITLE
[CU-86etc7m9c] Remove deprecated field in GitHub dependency bot and add new configuration about code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,43 +1,45 @@
 # CODEOWNERS file for PyFake-API-Server-Surveillance
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# These owners will be the default owners for everything in the repo.
-# Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
-* @Chisanan232
+# Default owner for everything in the repository
+*                                    @Chisanan232
+
+# Software license annotation
+/LICENSE                             @Chisanan232
 
 # Core application code
-/fake_api_server_plugin/ @Chisanan232
-/fake_api_server_plugin/ci/ @Chisanan232
-/fake_api_server_plugin/ci/surveillance/ @Chisanan232 @code-reviewers
+/fake_api_server_plugin/             @Chisanan232
+/fake_api_server_plugin/ci/          @Chisanan232
+/fake_api_server_plugin/ci/surveillance/  @Chisanan232
 
 # Test files
-/test/ @Chisanan232 @test-reviewers
-/test/unit_test/ @Chisanan232 @unit-test-team
-/test/integration_test/ @Chisanan232 @integration-test-team
-/test/system_test/ @Chisanan232 @system-test-team
+/test/                               @Chisanan232
+/test/unit_test/                     @Chisanan232
+/test/integration_test/              @Chisanan232
+/test/system_test/                   @Chisanan232
 
 # Documentation
-/docs/ @Chisanan232 @documentation-team
-*.md @Chisanan232 @documentation-team
-/mkdocs.yml @Chisanan232 @documentation-team
+/docs/                               @Chisanan232
+*.md                                 @Chisanan232
+/mkdocs.yml                          @Chisanan232
 
 # CI/CD and GitHub Actions
-/.github/workflows/ @Chisanan232 @devops-team
-/.github/actions/ @Chisanan232 @devops-team
-/scripts/ci/ @Chisanan232 @devops-team
-/action.yaml @Chisanan232 @devops-team
+/.github/workflows/                  @Chisanan232
+/.github/actions/                    @Chisanan232
+/scripts/ci/                         @Chisanan232
+/action.yaml                         @Chisanan232
 
 # Docker related files
-/Dockerfile @Chisanan232 @devops-team
-/README-DOCKER.md @Chisanan232 @devops-team @documentation-team
+/Dockerfile                          @Chisanan232
+/README-DOCKER.md                    @Chisanan232
 
 # Configuration files
-/pyproject.toml @Chisanan232 @core-maintainers
-/poetry.lock @Chisanan232 @core-maintainers
-/.pre-commit-config.yaml @Chisanan232 @core-maintainers
-/.pylintrc @Chisanan232 @core-maintainers
-/mypy.ini @Chisanan232 @core-maintainers
-/pytest.ini @Chisanan232 @test-reviewers
-/.coveragerc @Chisanan232 @test-reviewers
-/sonar-project.properties @Chisanan232 @devops-team
-/codecov.yml @Chisanan232 @devops-team
+/pyproject.toml                      @Chisanan232
+/poetry.lock                         @Chisanan232
+/.pre-commit-config.yaml             @Chisanan232
+/.pylintrc                           @Chisanan232
+/mypy.ini                            @Chisanan232
+/pytest.ini                          @Chisanan232
+/.coveragerc                         @Chisanan232
+/sonar-project.properties            @Chisanan232
+/codecov.yml                         @Chisanan232

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,43 @@
+# CODEOWNERS file for PyFake-API-Server-Surveillance
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in the repo.
+# Unless a later match takes precedence, they will be requested for review when someone opens a pull request.
+* @Chisanan232
+
+# Core application code
+/fake_api_server_plugin/ @Chisanan232
+/fake_api_server_plugin/ci/ @Chisanan232
+/fake_api_server_plugin/ci/surveillance/ @Chisanan232 @code-reviewers
+
+# Test files
+/test/ @Chisanan232 @test-reviewers
+/test/unit_test/ @Chisanan232 @unit-test-team
+/test/integration_test/ @Chisanan232 @integration-test-team
+/test/system_test/ @Chisanan232 @system-test-team
+
+# Documentation
+/docs/ @Chisanan232 @documentation-team
+*.md @Chisanan232 @documentation-team
+/mkdocs.yml @Chisanan232 @documentation-team
+
+# CI/CD and GitHub Actions
+/.github/workflows/ @Chisanan232 @devops-team
+/.github/actions/ @Chisanan232 @devops-team
+/scripts/ci/ @Chisanan232 @devops-team
+/action.yaml @Chisanan232 @devops-team
+
+# Docker related files
+/Dockerfile @Chisanan232 @devops-team
+/README-DOCKER.md @Chisanan232 @devops-team @documentation-team
+
+# Configuration files
+/pyproject.toml @Chisanan232 @core-maintainers
+/poetry.lock @Chisanan232 @core-maintainers
+/.pre-commit-config.yaml @Chisanan232 @core-maintainers
+/.pylintrc @Chisanan232 @core-maintainers
+/mypy.ini @Chisanan232 @core-maintainers
+/pytest.ini @Chisanan232 @test-reviewers
+/.coveragerc @Chisanan232 @test-reviewers
+/sonar-project.properties @Chisanan232 @devops-team
+/codecov.yml @Chisanan232 @devops-team

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Chisanan232"
     labels:
       - "🔍 enhancement"
       - "🤖 github actions"
@@ -18,8 +16,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    reviewers:
-      - "Chisanan232"
     labels:
       - "🔎 enhancement"
       - "🐍 python"


### PR DESCRIPTION
[//]: # (The target why you modify something.)
## _Target_

[//]: # (The summary what you did or your target.)
* ### Task summary:

    Remove deprecated field in GitHub dependency bot and add new configuration about code owners.

[//]: # (The task ID in ClickUp [project: https://app.clickup.com/9018752317/v/f/90183126979/90182605225] which maps this change.)
* ### Task tickets:

    * Task ID: CU-86etc7m9c.
    * Relative task IDs:
        * N/A.
    * Relative PRs:
        * N/A.

[//]: # (The key changes like demonstration, as-is & to-be, etc. for reviewers could be faster understand what it changes)
* ### Key point change (optional):

    https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/.
    <img width="927" alt="Screenshot 2025-05-06 at 12 03 06 PM" src="https://github.com/user-attachments/assets/da23db3b-378f-4345-8452-3433e7807f98" />


[//]: # (What's the scope in project it would affect with your modify? For example, would it affect CI workflow? Or any feature usage? Please list all the items which may be affected.)
## _Effecting Scope_

* Adjust the configuration only.


[//]: # (The brief of major changes what your modify. Please list it.)
## _Description_

* Remove the deprecated field `reviewers` in GitHub dependency bot configuration.
* Add a new configuration about code owners.
